### PR TITLE
Log Spam "range was referenced but it does not exists" Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,13 @@ repositories {
     maven {url "https://repo.spongepowered.org/maven"} // mixin
     maven {url 'https://maven.parchmentmc.org'}//Parchment
     maven {url "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/"}//Fuzs Mod Resources
+    // Reach Entity Attributes
+    maven {
+        url "https://maven.jamieswhiteshirt.com/libs-release"
+        content {
+            includeGroup "com.jamieswhiteshirt"
+        }
+    }
 }
 
 dependencies {
@@ -25,6 +32,8 @@ dependencies {
 	}
 	modImplementation "net.fabricmc:fabric-loader:${project._loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project._loader_api_version}"
+
+    include modImplementation("com.jamieswhiteshirt:reach-entity-attributes:$project._rea_version")
 
 	modImplementation ("com.stereowalker.unionlib:UnionLib:${_minecraft_version}-${_unionlib_version}-${_loader}")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ _loader_api_version    = 0.92.5+1.20.1
 ## Mod Properties
 _mod_name          = Reforged
 _mod_id            = tiered
-_mod_version       = 1.0.9
+_mod_version       = 1.0.10
 _mod_release       = release
 _mod_environment   = client & server
 _mod_license       = MIT

--- a/gradle.properties
+++ b/gradle.properties
@@ -36,3 +36,4 @@ _mod_page          = https://www.curseforge.com/minecraft/mc-mods/tiered-forge
 _mod_description   = Adds tiers to tools. \nThis is a forge port of the fabric mod. Here is the link https://www.curseforge.com/minecraft/mc-mods/tiered. CF https://www.curseforge.com/minecraft/mc-mods/tiered-forge, Modrinth https://modrinth.com/mod/tiered
 ##Misc Properties
 curiosVersion = 8.0.0
+_rea_version=2.4.0

--- a/src/main/resources/data/tiered/tiered_modifiers/tiers/melee_weapons/extended.json
+++ b/src/main/resources/data/tiered/tiered_modifiers/tiers/melee_weapons/extended.json
@@ -8,7 +8,7 @@
   },
   "attributes": [
     {
-      "type": "minecraft:player.block_interaction_range",
+      "type": "reach-entity-attributes:attack_range",
       "modifier": {
         "id": "tiered:extended_0",
         "operation": "ADD_VALUE",
@@ -19,7 +19,7 @@
       ]
     },
     {
-      "type": "minecraft:player.entity_interaction_range",
+      "type": "reach-entity-attributes:reach",
       "modifier": {
         "id": "tiered:extended_1",
         "operation": "ADD_VALUE",

--- a/src/main/resources/data/tiered/tiered_modifiers/tiers/tools/extended.json
+++ b/src/main/resources/data/tiered/tiered_modifiers/tiers/tools/extended.json
@@ -8,7 +8,7 @@
   },
   "attributes": [
     {
-      "type": "minecraft:player.block_interaction_range",
+      "type": "reach-entity-attributes:attack_range",
       "modifier": {
         "id": "tiered:extended",
         "operation": "ADD_VALUE",
@@ -19,7 +19,7 @@
       ]
     },
     {
-      "type": "minecraft:player.entity_interaction_range",
+      "type": "reach-entity-attributes:reach",
       "modifier": {
         "id": "tiered:extended",
         "operation": "ADD_VALUE",


### PR DESCRIPTION
This is a fix for fabric 1.20.1 log spam / crashing that occurs with Reforged.
This mod pulls in the extra dependency of jamieswhiteshirt:reach-entity-attribute and uses that instead of the generic minecraft attributes (which is inconsistent and has issues based on what version is used)

Log that is spammed:
```
[Render thread/WARN]:minecraft:player.block_interaction_range was referenced as an attribute type, but it does not exist! A data file in /tiered/item_attributes/ has an invalid type property.
[Render thread/WARN]:minecraft:player.entity_interaction_range was referenced as an attribute type, but it does not exist! A data file in /tiered/item_attributes/ has an invalid type property
```

Active related issues:
https://github.com/Stereowalker/Reforged/issues/149
https://github.com/Stereowalker/Reforged/issues/147
https://github.com/Stereowalker/Reforged/issues/143